### PR TITLE
Add Prediction builder

### DIFF
--- a/examples/apollo-service-example/src/main/java/com/spotify/zoltar/examples/apollo/IrisPrediction.java
+++ b/examples/apollo-service-example/src/main/java/com/spotify/zoltar/examples/apollo/IrisPrediction.java
@@ -25,6 +25,7 @@ import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.featran.FeatureSpec;
 import com.spotify.futures.CompletableFutures;
+import com.spotify.zoltar.DefaultPredictorBuilder;
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.IrisFeaturesSpec;
 import com.spotify.zoltar.IrisFeaturesSpec.Iris;
@@ -87,7 +88,9 @@ public class IrisPrediction {
       return CompletableFutures.allAsList(predictions);
     };
 
-    predictor = Predictor.create(modelLoader, extractFn, predictFn);
+    predictor = DefaultPredictorBuilder
+        .create(modelLoader, extractFn, predictFn)
+        .predictor();
   }
 
   /**
@@ -131,7 +134,7 @@ public class IrisPrediction {
   private static long predictFn(final TensorFlowModel model, final Example example) {
     final byte[][] b = new byte[1][];
     b[0] = example.toByteArray();
-    try (Tensor<String> t = Tensors.create(b)) {
+    try (final Tensor<String> t = Tensors.create(b)) {
       final Session.Runner runner = model.instance().session().runner()
               .feed("input_example_tensor", t);
       final String op = "linear/head/predictions/class_ids";

--- a/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictor.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictor.java
@@ -1,0 +1,79 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import com.spotify.zoltar.PredictFns.AsyncPredictFn;
+import com.spotify.zoltar.PredictFns.PredictFn;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Allows E2E prediction given a recipe made of a {@link Model}, {@link FeatureExtractor}
+ * and a {@link PredictFn}.
+ *
+ * @param <InputT> type of the feature extraction input.
+ * @param <ValueT> type of the prediction output.
+ */
+@FunctionalInterface
+interface DefaultPredictor<InputT, ValueT> extends Predictor<InputT, ValueT> {
+
+  /**
+   * Returns a predictor given a {@link Model}, {@link FeatureExtractor} and a {@link
+   * AsyncPredictFn}.
+   *
+   * @param modelLoader model loader that loads the model to perform prediction on.
+   * @param featureExtractor a feature extractor to use to transform input into extracted features.
+   * @param predictFn a prediction function to perform prediction with {@link AsyncPredictFn}.
+   * @param <ModelT> underlying type of the {@link Model}.
+   * @param <InputT> type of the input to the {@link FeatureExtractor}.
+   * @param <VectorT> type of the output from {@link FeatureExtractor}.
+   * @param <ValueT> type of the prediction result.
+   */
+  static <ModelT extends Model<?>, InputT, VectorT, ValueT> DefaultPredictor<InputT, ValueT> create(
+      final ModelLoader<ModelT> modelLoader,
+      final FeatureExtractor<InputT, VectorT> featureExtractor,
+      final AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn) {
+    return (scheduler, timeout, inputs) -> {
+      final CompletableFuture<List<Prediction<InputT, ValueT>>> future = modelLoader.get()
+          .thenCompose(model -> {
+            try {
+              return predictFn.apply(model, featureExtractor.extract(inputs));
+            } catch (final Exception e) {
+              throw new CompletionException(e);
+            }
+          })
+          .toCompletableFuture();
+
+      final ScheduledFuture<?> schedule = scheduler.schedule(() -> {
+        future.completeExceptionally(new TimeoutException());
+      }, timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+      future.whenComplete((r, t) -> schedule.cancel(true));
+
+      return future;
+    };
+  }
+
+}

--- a/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictorBuilder.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictorBuilder.java
@@ -1,0 +1,155 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import com.google.auto.value.AutoValue;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
+import com.spotify.zoltar.PredictFns.AsyncPredictFn;
+import com.spotify.zoltar.PredictFns.PredictFn;
+
+/**
+ * Entry point for prediction. Default implementation of a PredictorBuilder that holds the necessary
+ * info to build a {@link Predictor}.
+ *
+ * @param <ModelT>  underlying type of the {@link Model}.
+ * @param <InputT>  type of the input to the {@link FeatureExtractor}.
+ * @param <VectorT> type of the output from {@link FeatureExtractor}.
+ * @param <ValueT>  type of the prediction result.
+ */
+@AutoValue
+public abstract class DefaultPredictorBuilder<ModelT extends Model<?>, InputT, VectorT, ValueT>
+    implements PredictorBuilder<ModelT, InputT, VectorT, ValueT> {
+
+  /**
+   * Returns a context given a {@link Model}, {@link FeatureExtractor} and a {@link PredictFn}.
+   *
+   * @param modelLoader model loader that loads the model to perform prediction on.
+   * @param extractFn   a feature extract function to use to transform input into extracted
+   *                    features.
+   * @param predictFn   a prediction function to perform prediction with {@link PredictFn}.
+   * @param <ModelT>    underlying type of the {@link Model}.
+   * @param <InputT>    type of the input to the {@link FeatureExtractor}.
+   * @param <VectorT>   type of the output from {@link FeatureExtractor}.
+   * @param <ValueT>    type of the prediction result.
+   */
+  @SuppressWarnings("checkstyle:LineLength")
+  public static <ModelT extends Model<?>, InputT, VectorT, ValueT> DefaultPredictorBuilder<ModelT, InputT, VectorT, ValueT> create(
+      final ModelLoader<ModelT> modelLoader,
+      final ExtractFn<InputT, VectorT> extractFn,
+      final PredictFn<ModelT, InputT, VectorT, ValueT> predictFn) {
+    return create(modelLoader, FeatureExtractor.create(extractFn), AsyncPredictFn.lift(predictFn));
+  }
+
+  /**
+   * Returns a context given a {@link Model}, {@link FeatureExtractor} and a {@link
+   * AsyncPredictFn}.
+   *
+   * @param modelLoader model loader that loads the model to perform prediction on.
+   * @param extractFn   a feature extract function to use to transform input into extracted
+   *                    features.
+   * @param predictFn   a prediction function to perform prediction with {@link AsyncPredictFn}.
+   * @param <ModelT>    underlying type of the {@link Model}.
+   * @param <InputT>    type of the input to the {@link FeatureExtractor}.
+   * @param <VectorT>   type of the output from {@link FeatureExtractor}.
+   * @param <ValueT>    type of the prediction result.
+   */
+  @SuppressWarnings("checkstyle:LineLength")
+  public static <ModelT extends Model<?>, InputT, VectorT, ValueT> DefaultPredictorBuilder<ModelT, InputT, VectorT, ValueT> create(
+      final ModelLoader<ModelT> modelLoader,
+      final ExtractFn<InputT, VectorT> extractFn,
+      final AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn) {
+    return create(modelLoader, FeatureExtractor.create(extractFn), predictFn);
+  }
+
+  /**
+   * Returns a context given a {@link Model}, {@link FeatureExtractor} and a {@link PredictFn}.
+   *
+   * @param modelLoader      model loader that loads the model to perform prediction on.
+   * @param featureExtractor a feature extractor to use to transform input into extracted features.
+   * @param predictFn        a prediction function to perform prediction with {@link PredictFn}.
+   * @param <ModelT>         underlying type of the {@link Model}.
+   * @param <InputT>         type of the input to the {@link FeatureExtractor}.
+   * @param <VectorT>        type of the output from {@link FeatureExtractor}.
+   * @param <ValueT>         type of the prediction result.
+   */
+  @SuppressWarnings("checkstyle:LineLength")
+  public static <ModelT extends Model<?>, InputT, VectorT, ValueT> DefaultPredictorBuilder<ModelT, InputT, VectorT, ValueT> create(
+      final ModelLoader<ModelT> modelLoader,
+      final FeatureExtractor<InputT, VectorT> featureExtractor,
+      final PredictFn<ModelT, InputT, VectorT, ValueT> predictFn) {
+    return create(modelLoader, featureExtractor, AsyncPredictFn.lift(predictFn));
+  }
+
+  /**
+   * Returns a context given a {@link Model}, {@link FeatureExtractor} and a {@link PredictFn}.
+   *
+   * @param modelLoader      model loader that loads the model to perform prediction on.
+   * @param featureExtractor a feature extractor to use to transform input into extracted features.
+   * @param predictFn        a prediction function to perform prediction with {@link
+   *                         AsyncPredictFn}.
+   * @param <ModelT>         underlying type of the {@link Model}.
+   * @param <InputT>         type of the input to the {@link FeatureExtractor}.
+   * @param <VectorT>        type of the output from {@link FeatureExtractor}.
+   * @param <ValueT>         type of the prediction result.
+   */
+  @SuppressWarnings("checkstyle:LineLength")
+  public static <ModelT extends Model<?>, InputT, VectorT, ValueT> DefaultPredictorBuilder<ModelT, InputT, VectorT, ValueT> create(
+      final ModelLoader<ModelT> modelLoader,
+      final FeatureExtractor<InputT, VectorT> featureExtractor,
+      final AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn) {
+    return new AutoValue_DefaultPredictorBuilder.Builder<ModelT, InputT, VectorT, ValueT>()
+        .modelLoader(modelLoader)
+        .featureExtractor(featureExtractor)
+        .predictFn(predictFn)
+        .build();
+  }
+
+  public abstract ModelLoader<ModelT> modelLoader();
+
+  public abstract FeatureExtractor<InputT, VectorT> featureExtractor();
+
+  public abstract AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn();
+
+  public abstract Builder<ModelT, InputT, VectorT, ValueT> toBuilder();
+
+  public Predictor<InputT, ValueT> predictor() {
+    return DefaultPredictor.create(modelLoader(), featureExtractor(), predictFn());
+  }
+
+  /**
+   * Internal PredictorBuilder builder.
+   */
+  @AutoValue.Builder
+  abstract static class Builder<ModelT extends Model<?>, InputT, VectorT, ValueT> {
+
+    public abstract Builder<ModelT, InputT, VectorT, ValueT> modelLoader(
+        ModelLoader<ModelT> modelLoader);
+
+    public abstract Builder<ModelT, InputT, VectorT, ValueT> featureExtractor(
+        FeatureExtractor<InputT, VectorT> featureExtractor);
+
+    public abstract Builder<ModelT, InputT, VectorT, ValueT> predictFn(
+        AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn);
+
+    public abstract DefaultPredictorBuilder<ModelT, InputT, VectorT, ValueT> build();
+  }
+
+}

--- a/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictorTimeoutScheduler.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/DefaultPredictorTimeoutScheduler.java
@@ -1,0 +1,46 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Default {@link Predictor} {@link ScheduledExecutorService} supplier implementation
+ * for timeout scheduling.
+ */
+final class DefaultPredictorTimeoutScheduler implements PredictorTimeoutScheduler {
+
+  private static final ScheduledExecutorService SCHEDULER =
+      Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+
+  private DefaultPredictorTimeoutScheduler() {
+  }
+
+  public static DefaultPredictorTimeoutScheduler create() {
+    return new DefaultPredictorTimeoutScheduler();
+  }
+
+  @Override
+  public ScheduledExecutorService scheduler() {
+    return SCHEDULER;
+  }
+}

--- a/zoltar-core/src/main/java/com/spotify/zoltar/ModelLoader.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/ModelLoader.java
@@ -57,7 +57,7 @@ public interface ModelLoader<M extends Model<?>> {
     return () -> CompletableFuture.supplyAsync(() -> {
       try {
         return supplier.get();
-      } catch (Exception e) {
+      } catch (final Exception e) {
         throw new CompletionException(e);
       }
     });
@@ -75,15 +75,15 @@ public interface ModelLoader<M extends Model<?>> {
    *
    * @return Model instance
    */
-  default M get(Duration duration) throws InterruptedException,
-                                          ExecutionException,
-                                          TimeoutException {
+  default M get(final Duration duration) throws InterruptedException,
+                                                ExecutionException,
+                                                TimeoutException {
     return get()
         .toCompletableFuture()
         .get(duration.toMillis(), TimeUnit.MILLISECONDS);
   }
 
-  default <L extends ModelLoader<M>> L with(Function<ModelLoader<M>, L> fn) {
+  default <L extends ModelLoader<M>> L with(final Function<ModelLoader<M>, L> fn) {
     return fn.apply(this);
   }
 

--- a/zoltar-core/src/main/java/com/spotify/zoltar/Predictor.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/Predictor.java
@@ -45,15 +45,14 @@ public interface Predictor<InputT, ValueT> {
 
   /**
    * Functional interface. You should perform E2E feature extraction and prediction. See {@link
-   * DefaultPredictor#create(ModelLoader, FeatureExtractor, AsyncPredictFn)} for an
-   * example of usage.
+   * DefaultPredictorBuilder#create(ModelLoader, FeatureExtractor, AsyncPredictFn)} for an example
+   * of usage.
    *
-   * @param input a list of inputs to perform feature extraction and prediction on.
-   * @param timeout implementation specific timeout, see {@link Predictor#create(ModelLoader,
-   * FeatureExtractor, AsyncPredictFn)} for an example of usage.
-   * @param scheduler implementation specific scheduler, see {@link Predictor#create(ModelLoader,
-   * FeatureExtractor, AsyncPredictFn)} for an example of usage.
+   * @param input     a list of inputs to perform feature extraction and prediction on.
+   * @param timeout   implementation specific timeout.
+   * @param scheduler implementation specific scheduler.
    */
+  @SuppressWarnings("checkstyle:LineLength")
   CompletionStage<List<Prediction<InputT, ValueT>>> predict(ScheduledExecutorService scheduler,
                                                             Duration timeout,
                                                             InputT... input);

--- a/zoltar-core/src/main/java/com/spotify/zoltar/PredictorBuilder.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/PredictorBuilder.java
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import com.spotify.zoltar.PredictFns.AsyncPredictFn;
+import java.util.function.Function;
+
+/**
+ * PredictorBuilder holds the necessary info to build a {@link Predictor}.
+ *
+ * @param <ModelT>  underlying type of the {@link Model}.
+ * @param <InputT>  type of the input to the {@link FeatureExtractor}.
+ * @param <VectorT> type of the output from {@link FeatureExtractor}.
+ * @param <ValueT>  type of the prediction result.
+ */
+public interface PredictorBuilder<ModelT extends Model<?>, InputT, VectorT, ValueT> {
+
+  ModelLoader<ModelT> modelLoader();
+
+  FeatureExtractor<InputT, VectorT> featureExtractor();
+
+  AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn();
+
+  Predictor<InputT, ValueT> predictor();
+
+  default <C extends PredictorBuilder<ModelT, InputT, VectorT, ValueT>> C with(
+      final Function<PredictorBuilder<ModelT, InputT, VectorT, ValueT>, C> fn) {
+    return fn.apply(this);
+  }
+
+}

--- a/zoltar-core/src/main/java/com/spotify/zoltar/PredictorTimeoutScheduler.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/PredictorTimeoutScheduler.java
@@ -1,0 +1,33 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * {@link Predictor} {@link ScheduledExecutorService} supplier for timeout scheduling.
+ */
+@FunctionalInterface
+interface PredictorTimeoutScheduler {
+
+  ScheduledExecutorService scheduler();
+
+}

--- a/zoltar-core/src/test/java/com/spotify/zoltar/PredictorBuilderTest.java
+++ b/zoltar-core/src/test/java/com/spotify/zoltar/PredictorBuilderTest.java
@@ -1,0 +1,110 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.PredictFns.AsyncPredictFn;
+import com.spotify.zoltar.PredictFns.PredictFn;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class PredictorBuilderTest {
+
+  static class DummyModel implements Model<Object> {
+
+    @Override
+    public Object instance() {
+      return new Object();
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+  }
+
+  static final class IdentityPredictorBuilder<ModelT extends Model<?>, InputT, VectorT, ValueT>
+      implements PredictorBuilder<ModelT, InputT, VectorT, ValueT> {
+
+    private final PredictorBuilder<ModelT, InputT, VectorT, ValueT> predictorBuilder;
+
+    IdentityPredictorBuilder(final PredictorBuilder<ModelT, InputT, VectorT, ValueT> predictorBuilder) {
+      this.predictorBuilder = predictorBuilder;
+    }
+
+    public static <ModelT extends Model<?>, InputT, VectorT, ValueT> Function<PredictorBuilder<ModelT, InputT, VectorT, ValueT>, IdentityPredictorBuilder<ModelT, InputT, VectorT, ValueT>> decorate() {
+      return IdentityPredictorBuilder::new;
+    }
+
+    @Override
+    public ModelLoader<ModelT> modelLoader() {
+      return predictorBuilder.modelLoader();
+    }
+
+    @Override
+    public FeatureExtractor<InputT, VectorT> featureExtractor() {
+      return predictorBuilder.featureExtractor();
+    }
+
+    @Override
+    public AsyncPredictFn<ModelT, InputT, VectorT, ValueT> predictFn() {
+      return predictorBuilder.predictFn();
+    }
+
+    @Override
+    public Predictor<InputT, ValueT> predictor() {
+      return predictorBuilder.predictor();
+    }
+  }
+
+  @Test
+  public void identityDecoration() throws ExecutionException, InterruptedException {
+    final ModelLoader<DummyModel> loader =
+        ModelLoader.lift(DummyModel::new);
+    final SingleExtractFn<Integer, Float> extractFn = input -> (float) input / 10;
+    final PredictFn<DummyModel, Integer, Float, Float> predictFn = (model, vectors) -> {
+      return vectors.stream()
+          .map(vector -> Prediction.create(vector.input(), vector.value() * 2))
+          .collect(Collectors.toList());
+    };
+
+    final List<Prediction<Integer, Float>> predictions =
+        DefaultPredictorBuilder
+            .create(loader, extractFn, predictFn)
+            .with(IdentityPredictorBuilder.decorate())
+            .predictor()
+            .predict(1)
+            .toCompletableFuture()
+            .get();
+
+    assertThat(predictions.size(), is(1));
+    assertThat(predictions.get(0), is(Prediction.create(1, 0.2f)));
+
+  }
+
+}

--- a/zoltar-core/src/test/java/com/spotify/zoltar/PredictorTest.java
+++ b/zoltar-core/src/test/java/com/spotify/zoltar/PredictorTest.java
@@ -67,13 +67,15 @@ public class PredictorTest {
 
     try {
       final ModelLoader<DummyModel> loader = ModelLoader.lift(DummyModel::new);
-      Predictor.create(loader, extractFn, predictFn)
+      DefaultPredictorBuilder
+          .create(loader, extractFn, predictFn)
+          .predictor()
           .predict(predictionTimeout, new Object())
           .toCompletableFuture()
           .get(wait.toMillis(), TimeUnit.MILLISECONDS);
 
       fail("should throw TimeoutException");
-    } catch (Exception e) {
+    } catch (final Exception e) {
       assertTrue(e.getCause() instanceof TimeoutException);
     }
   }
@@ -86,7 +88,9 @@ public class PredictorTest {
         (model, vectors) -> CompletableFuture.completedFuture(Collections.emptyList());
 
     final ModelLoader<DummyModel> loader = ModelLoader.lift(DummyModel::new);
-    Predictor.create(loader, extractFn, predictFn)
+    DefaultPredictorBuilder
+        .create(loader, extractFn, predictFn)
+        .predictor()
         .predict()
         .toCompletableFuture()
         .get(wait.toMillis(), TimeUnit.MILLISECONDS);
@@ -103,11 +107,13 @@ public class PredictorTest {
     };
 
     final ModelLoader<DummyModel> loader = ModelLoader.lift(DummyModel::new);
-    final List<Prediction<Integer, Float>> predictions = Predictor
-        .create(loader, extractFn, predictFn)
-        .predict(1)
-        .toCompletableFuture()
-        .get(wait.toMillis(), TimeUnit.MILLISECONDS);
+    final List<Prediction<Integer, Float>> predictions =
+        DefaultPredictorBuilder
+            .create(loader, extractFn, predictFn)
+            .predictor()
+            .predict(1)
+            .toCompletableFuture()
+            .get(wait.toMillis(), TimeUnit.MILLISECONDS);
 
     assertThat(predictions.size(), is(1));
     assertThat(predictions.get(0), is(Prediction.create(1, 0.2f)));

--- a/zoltar-tensorflow/src/test/java/com/spotify/zoltar/tf/TensorFlowGraphModelTest.java
+++ b/zoltar-tensorflow/src/test/java/com/spotify/zoltar/tf/TensorFlowGraphModelTest.java
@@ -25,11 +25,11 @@ import static org.junit.Assert.assertEquals;
 
 import com.spotify.featran.java.JFeatureSpec;
 import com.spotify.featran.transformers.Identity;
+import com.spotify.zoltar.DefaultPredictorBuilder;
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.ModelLoader;
 import com.spotify.zoltar.PredictFns.PredictFn;
 import com.spotify.zoltar.Prediction;
-import com.spotify.zoltar.Predictor;
 import com.spotify.zoltar.featran.FeatranExtractFns;
 import java.io.IOException;
 import java.net.URI;
@@ -60,8 +60,8 @@ public class TensorFlowGraphModelTest {
   private Path createADummyTFGraph() throws IOException {
     final Path graphFile;
     try (
-        Graph graph = new Graph();
-        Tensor<Double> t = Tensors.create(2.0D)
+        final Graph graph = new Graph();
+        final Tensor<Double> t = Tensors.create(2.0D)
     ) {
       final Output<Double> input = graph.opBuilder("Placeholder", inputOpName)
           .setAttr("dtype", t.dataType())
@@ -84,10 +84,10 @@ public class TensorFlowGraphModelTest {
   @Test
   public void testDummyLoadOfTensorFlowGraph() throws Exception {
     final Path graphFile = createADummyTFGraph();
-    try (TensorFlowGraphModel model =
+    try (final TensorFlowGraphModel model =
              TensorFlowGraphModel.create(graphFile.toUri(), null, null);
-         Session session = model.instance();
-         Tensor<Double> double3 = Tensors.create(3.0D)) {
+         final Session session = model.instance();
+         final Tensor<Double> double3 = Tensors.create(3.0D)) {
       List<Tensor<?>> result = null;
       try {
         result = session.runner()
@@ -107,10 +107,10 @@ public class TensorFlowGraphModelTest {
   public void testDummyLoadOfTensorFlowGraphWithPrefix() throws Exception {
     final String prefix = "test";
     final Path graphFile = createADummyTFGraph();
-    try (TensorFlowGraphModel model =
+    try (final TensorFlowGraphModel model =
              TensorFlowGraphModel.create(graphFile.toUri(), null, prefix);
-         Session session = model.instance();
-         Tensor<Double> double3 = Tensors.create(3.0D)) {
+         final Session session = model.instance();
+         final Tensor<Double> double3 = Tensors.create(3.0D)) {
       List<Tensor<?>> result = null;
       try {
         result = session.runner()
@@ -162,8 +162,9 @@ public class TensorFlowGraphModelTest {
 
     final Double[] input = new Double[]{0.0D, 1.0D, 7.0D};
     final double[] expected = Arrays.stream(input).mapToDouble(d -> d * 2.0D).toArray();
-    final CompletableFuture<double[]> result = Predictor
+    final CompletableFuture<double[]> result = DefaultPredictorBuilder
         .create(tfModel, extractFn, predictFn)
+        .predictor()
         .predict(input)
         .thenApply(predictions -> {
           return predictions.stream()

--- a/zoltar-tensorflow/src/test/java/com/spotify/zoltar/tf/TensorFlowModelTest.java
+++ b/zoltar-tensorflow/src/test/java/com/spotify/zoltar/tf/TensorFlowModelTest.java
@@ -22,6 +22,7 @@ package com.spotify.zoltar.tf;
 
 import com.google.common.collect.ImmutableMap;
 import com.spotify.futures.CompletableFutures;
+import com.spotify.zoltar.DefaultPredictorBuilder;
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.IrisFeaturesSpec;
 import com.spotify.zoltar.IrisFeaturesSpec.Iris;
@@ -71,7 +72,9 @@ public class TensorFlowModelTest {
     final ExtractFn<Iris, Example> extractFn = FeatranExtractFns
         .example(IrisFeaturesSpec.irisFeaturesSpec(), settings);
 
-    return Predictor.create(model, extractFn, predictFn);
+    return DefaultPredictorBuilder
+        .create(model, extractFn, predictFn)
+        .predictor();
   }
 
   @Test
@@ -101,7 +104,7 @@ public class TensorFlowModelTest {
     // rank 1 cause we need to account for batch
     final byte[][] b = new byte[1][];
     b[0] = example.toByteArray();
-    try (Tensor<String> t = Tensors.create(b)) {
+    try (final Tensor<String> t = Tensors.create(b)) {
       final Session.Runner runner = model.instance().session().runner()
           .feed("input_example_tensor", t)
           .fetch("linear/head/predictions/class_ids");

--- a/zoltar-xgboost/src/test/java/com/spotify/zoltar/xgboost/XGBoostModelTest.java
+++ b/zoltar-xgboost/src/test/java/com/spotify/zoltar/xgboost/XGBoostModelTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.spotify.futures.CompletableFutures;
+import com.spotify.zoltar.DefaultPredictorBuilder;
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.IrisFeaturesSpec;
 import com.spotify.zoltar.IrisFeaturesSpec.Iris;
@@ -88,7 +89,9 @@ public class XGBoostModelTest {
     final ExtractFn<Iris, LabeledPoint> extractFn = FeatranExtractFns
         .labeledPoints(IrisFeaturesSpec.irisFeaturesSpec(), settings);
 
-    return Predictor.create(model, extractFn, predictFn);
+    return DefaultPredictorBuilder
+        .create(model, extractFn, predictFn)
+        .predictor();
   }
 
   @Test

--- a/zoltar-xgboost/src/test/java/com/spotify/zoltar/xgboost/XGBoostModelTest.java
+++ b/zoltar-xgboost/src/test/java/com/spotify/zoltar/xgboost/XGBoostModelTest.java
@@ -72,7 +72,7 @@ public class XGBoostModelTest {
                 int idx = IntStream.range(0, score.length)
                     .reduce((i, j) -> score[i] >= score[j] ? i : j)
                     .getAsInt();
-                return Prediction.create(vector.input(), (long)idx);
+                return Prediction.create(vector.input(), (long) idx);
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -83,7 +83,7 @@ public class XGBoostModelTest {
     };
 
     final String settings = new String(Files.readAllBytes(Paths.get(settingsUri)),
-        StandardCharsets.UTF_8);
+                                       StandardCharsets.UTF_8);
     final XGBoostLoader model = XGBoostLoader.create(trainedModelUri.toString());
 
     final ExtractFn<Iris, LabeledPoint> extractFn = FeatranExtractFns
@@ -99,8 +99,8 @@ public class XGBoostModelTest {
     final Iris[] irisStream = IrisHelper.getIrisTestData();
 
     final Map<Integer, String> classToId = ImmutableMap.of(0, "Iris-setosa",
-        1, "Iris-versicolor",
-        2, "Iris-virginica");
+                                                           1, "Iris-versicolor",
+                                                           2, "Iris-virginica");
 
     final CompletableFuture<Integer> sum = getXGBoostIrisPredictor()
         .predict(Duration.ofSeconds(10), irisStream)


### PR DESCRIPTION
Introduce `PredictionBuilder` to wrap the creation of a predictor. The idea behind this is, is to allow us to compose different `PredictionBuilder` in the future and get the `Predictor` for that composed behavior.