### PR TITLE
Move iris test helper to src/main

### DIFF
--- a/zoltar-api/pom.xml
+++ b/zoltar-api/pom.xml
@@ -60,13 +60,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>zoltar-tests</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zoltar-tensorflow/pom.xml
+++ b/zoltar-tensorflow/pom.xml
@@ -58,13 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>zoltar-tests</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/zoltar-tests/pom.xml
+++ b/zoltar-tests/pom.xml
@@ -244,10 +244,11 @@
         <version>3.3.1</version>
         <executions>
           <execution>
-            <id>scala-add-sources</id>
+            <id>scala-compile-first</id>
             <phase>process-resources</phase>
             <goals>
               <goal>add-source</goal>
+              <goal>compile</goal>
             </goals>
           </execution>
           <execution>
@@ -287,17 +288,6 @@
         <configuration>
           <skip>true</skip>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/zoltar-tests/src/main/java/com/spotify/zoltar/IrisHelper.java
+++ b/zoltar-tests/src/main/java/com/spotify/zoltar/IrisHelper.java
@@ -25,12 +25,15 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import scala.Option;
 
+/**
+ * Helper class to generate Iris test data.
+ */
 public class IrisHelper {
 
   private IrisHelper() {
   }
 
-  public static IrisFeaturesSpec.Iris fromCSVString(final String features) {
+  private static IrisFeaturesSpec.Iris fromCsvString(final String features) {
     final String[] strs = features.split(",");
     return new IrisFeaturesSpec.Iris(Option.apply(Double.parseDouble(strs[0])),
             Option.apply(Double.parseDouble(strs[1])),
@@ -39,11 +42,14 @@ public class IrisHelper {
             Option.apply(strs[4]));
   }
 
+  /**
+   * Get Iris test data.
+   */
   public static IrisFeaturesSpec.Iris[] getIrisTestData() throws Exception {
     final URI data = IrisHelper.class.getResource("/iris.csv").toURI();
     return Files.readAllLines(Paths.get(data))
         .stream()
-        .map(IrisHelper::fromCSVString)
+        .map(IrisHelper::fromCsvString)
         .toArray(IrisFeaturesSpec.Iris[]::new);
   }
 

--- a/zoltar-xgboost/pom.xml
+++ b/zoltar-xgboost/pom.xml
@@ -41,13 +41,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>zoltar-tests</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This partly solves #72 - I think to take this the rest of the way we should move those shared test classes in the TF and XGBoost models into `main` of `zoltar-tests`.