### PR TITLE
Workaround for type inference of generic exception

### DIFF
--- a/examples/apollo-service-example/src/main/java/com/spotify/zoltar/examples/apollo/IrisPredictionHandler.java
+++ b/examples/apollo-service-example/src/main/java/com/spotify/zoltar/examples/apollo/IrisPredictionHandler.java
@@ -98,7 +98,7 @@ final class IrisPredictionHandler {
               .findFirst()
               .map(Prediction::value)
               .map(idToClass::get)
-              .orElseThrow(() -> new RuntimeException("we expect a prediction"));
+              .<RuntimeException>orElseThrow(() -> new RuntimeException("we expect a prediction"));
         });
   }
 }


### PR DESCRIPTION
`mvn package` fails for the apollo example due to a type inference bug on generic exceptions: https://bugs.openjdk.java.net/browse/JDK-8054569. Supplying a type param gets around this.

@regadas PTAL