### PR TITLE
Add custom metrics example

### DIFF
--- a/examples/custom-metrics/pom.xml
+++ b/examples/custom-metrics/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <artifactId>zoltar-parent</artifactId>
+    <groupId>com.spotify</groupId>
+    <version>0.3.2-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>custom-metrics</artifactId>
+
+  <properties>
+    <findbugs.excludeFilterFile>findbugsexclude.xml</findbugs.excludeFilterFile>
+    <maven.install.skip>true</maven.install.skip>
+    <checkstyle.violationSeverity>warning</checkstyle.violationSeverity>
+    <jacoco.skip>true</jacoco.skip>
+    <jackson.version>2.9.2</jackson.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.spotify</groupId>
+        <artifactId>zoltar-bom</artifactId>
+        <version>0.3.2-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>zoltar-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>zoltar-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>zoltar-tests</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/CustomMetricsExample.java
+++ b/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/CustomMetricsExample.java
@@ -1,0 +1,190 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.metrics;
+
+import com.codahale.metrics.Counter;
+import com.google.auto.value.AutoValue;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractor;
+import com.spotify.zoltar.Model;
+import com.spotify.zoltar.ModelLoader;
+import com.spotify.zoltar.PredictFns.PredictFn;
+import com.spotify.zoltar.Prediction;
+import com.spotify.zoltar.Predictor;
+import com.spotify.zoltar.PredictorBuilder;
+import com.spotify.zoltar.Predictors;
+import com.spotify.zoltar.Vector;
+import com.spotify.zoltar.loaders.Preloader;
+import com.spotify.zoltar.metrics.FeatureExtractorMetrics;
+import com.spotify.zoltar.metrics.Instrumentations;
+import com.spotify.zoltar.metrics.PredictFnMetrics;
+import com.spotify.zoltar.metrics.PredictMetrics;
+import com.spotify.zoltar.metrics.PredictorMetrics;
+import com.spotify.zoltar.metrics.VectorMetrics;
+import com.spotify.zoltar.metrics.semantic.SemanticPredictorMetrics;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+/**
+ * Example showing how to add custom metrics to a Predictor.
+ */
+class CustomMetricsExample implements Predictor<Integer, Float> {
+
+  private PredictorBuilder<DummyModel, Integer, Float, Float> predictorBuilder;
+
+  /**
+   * Define a class containing all the additional metrics we want to register.
+   */
+  @AutoValue
+  abstract static class CustomMetrics {
+    abstract Counter negativePredictCount();
+
+    abstract Counter negativeExtractCount();
+
+    static CustomMetrics create(final SemanticMetricRegistry registry, final MetricId metricId) {
+      final MetricId predictCountId = metricId.tagged("what", "negativePredictCount");
+      final MetricId extractCountId = metricId.tagged("what", "negativeExtractCount");
+      final Counter negativePredictCount = registry.counter(predictCountId);
+      final Counter negativeExtractCount = registry.counter(extractCountId);
+
+      return new AutoValue_CustomMetricsExample_CustomMetrics(
+          negativePredictCount,
+          negativeExtractCount);
+    }
+  }
+
+  /**
+   * Define an implementation of PredictorMetrics, which will hold metrics for feature extraction
+   * and prediction. In this example we don't make use of the model ID.
+   */
+  @AutoValue
+  abstract static class CustomPredictorMetrics implements PredictorMetrics<Integer, Float, Float> {
+    abstract LoadingCache<Model.Id, CustomMetrics> metricsCache();
+
+    static CustomPredictorMetrics create(final SemanticMetricRegistry registry,
+                                         final MetricId metricId) {
+      final LoadingCache<Model.Id, CustomMetrics> metersCache =
+          CacheBuilder.<Model.Id, CustomMetrics>newBuilder()
+              .build(new CacheLoader<Model.Id, CustomMetrics>() {
+                @Override
+                public CustomMetrics load(final Model.Id id) {
+                  return CustomMetrics.create(registry, metricId.tagged("model", id.value()));
+                }
+              });
+
+      return new AutoValue_CustomMetricsExample_CustomPredictorMetrics(metersCache);
+    }
+
+    @Override
+    public PredictFnMetrics<Integer, Float> predictFnMetrics() {
+      return id -> {
+        final CustomMetrics metrics = metricsCache().getUnchecked(id);
+        final Counter negativePredictCounter = metrics.negativePredictCount();
+        return NegativePredictMetrics.create(negativePredictCounter);
+      };
+    }
+
+    @Override
+    public FeatureExtractorMetrics<Integer, Float> featureExtractorMetrics() {
+      return id -> {
+        final CustomMetrics metrics = metricsCache().getUnchecked(id);
+        final Counter negativeExtractCounter = metrics.negativeExtractCount();
+        return NegativeExtractMetrics.create(negativeExtractCounter);
+      };
+    }
+  }
+
+  /**
+   * To define a metric you want to measure for prediction, implement PredictMetrics.
+   */
+  @AutoValue
+  abstract static class NegativePredictMetrics implements PredictMetrics<Integer, Float> {
+    abstract Counter negativePredictCount();
+
+    static NegativePredictMetrics create(final Counter negativeCount) {
+      return new AutoValue_CustomMetricsExample_NegativePredictMetrics(negativeCount);
+    }
+
+    /**
+     * Here, given a list of predictions, we want to measure the number of negatives.
+     */
+    @Override
+    public void prediction(final List<Prediction<Integer, Float>> predictions) {
+      negativePredictCount().inc(predictions.stream().filter(x -> x.value() < 0).count());
+    }
+  }
+
+  /**
+   * To define a metric you want to measure for feature extraction, implement VectorMetrics.
+   */
+  @AutoValue
+  abstract static class NegativeExtractMetrics implements VectorMetrics<Integer, Float> {
+    abstract Counter negativeExtractCount();
+
+    static NegativeExtractMetrics create(final Counter negativeCount) {
+      return new AutoValue_CustomMetricsExample_NegativeExtractMetrics(negativeCount);
+    }
+
+    /**
+     * Here, given a list of feature extraction results, we want to count the number of negatives.
+     */
+    @Override
+    public void extraction(final List<Vector<Integer, Float>> vectors) {
+      negativeExtractCount().inc(vectors.stream().filter(v -> v.value() < 0).count());
+    }
+  }
+
+  CustomMetricsExample(final SemanticMetricRegistry metricRegistry, final MetricId metricId) {
+    final ModelLoader<DummyModel> modelLoader = ModelLoader
+        .lift(DummyModel::new)
+        .with(Preloader.preload(Duration.ofMinutes(1)));
+    final SingleExtractFn<Integer, Float> extractFn = input -> (float) input / 10;
+    final PredictFn<DummyModel, Integer, Float, Float> predictFn = (model, vectors) -> {
+      return vectors.stream()
+          .map(vector -> Prediction.create(vector.input(),vector.value() * 2))
+          .collect(Collectors.toList());
+    };
+
+    // We build the PredictorBuilder as usual, compose with the built-in metrics, and then compose
+    // with our custom metrics.
+    predictorBuilder = Predictors.newBuilder(
+        modelLoader,
+        FeatureExtractor.create(extractFn),
+        predictFn
+    ).with(Instrumentations.predictor(SemanticPredictorMetrics.create(metricRegistry, metricId))
+    ).with(Instrumentations.predictor(CustomPredictorMetrics.create(metricRegistry, metricId)));
+  }
+
+  @Override
+  public CompletionStage<List<Prediction<Integer, Float>>> predict(
+      final ScheduledExecutorService scheduler, final Duration timeout, final Integer... input) {
+    return predictorBuilder.predictor().predict(scheduler, timeout, input);
+  }
+
+}

--- a/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/DummyModel.java
+++ b/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/DummyModel.java
@@ -1,0 +1,38 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.metrics;
+
+import com.spotify.zoltar.Model;
+
+class DummyModel implements Model<Object> {
+  @Override
+  public Id id() {
+    return Id.create("dummy");
+  }
+
+  @Override
+  public Object instance() {
+    return new Object();
+  }
+
+  @Override
+  public void close() throws Exception {}
+}

--- a/examples/custom-metrics/src/test/java/com/spotify/zoltar/examples/metrics/CustomMetricsExampleTest.java
+++ b/examples/custom-metrics/src/test/java/com/spotify/zoltar/examples/metrics/CustomMetricsExampleTest.java
@@ -1,0 +1,43 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.metrics;
+
+import com.codahale.metrics.Counter;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import java.util.SortedMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CustomMetricsExampleTest {
+
+  @Test
+  public void testCustomMetrics() throws Exception {
+    final SemanticMetricRegistry registry = new SemanticMetricRegistry();
+    final MetricId metricId = MetricId.build().tagged("service", "my-application");
+    final CustomMetricsExample example = new CustomMetricsExample(registry, metricId);
+
+    example.predict(3, 1, -4, -42, 42, -10).toCompletableFuture().join();
+
+    registry.getCounters().values()
+        .forEach(counter -> Assert.assertEquals(3, counter.getCount()));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>zoltar-api</module>
     <module>zoltar-metrics</module>
     <module>examples/apollo-service-example</module>
+    <module>examples/custom-metrics</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
@regadas PTAL. Not sure this null count thing is really a good example, should I switch it to something more meaningful? (Also this doesn't track total nulls, only for the current batch, which seems kinda useless). 

Still todo:

- [x] Add more docs on custom metrics
- [x] tests?