### PR TITLE
Make InstrumentedPredictorBuilder public

### DIFF
--- a/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/InstrumentedPredictorBuilder.java
+++ b/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/InstrumentedPredictorBuilder.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
  * @param <ValueT>  type of the prediction result.
  */
 @AutoValue
-abstract class InstrumentedPredictorBuilder<ModelT extends Model<?>, InputT, VectorT, ValueT>
+public abstract class InstrumentedPredictorBuilder<ModelT extends Model<?>, InputT, VectorT, ValueT>
     implements PredictorBuilder<ModelT, InputT, VectorT, ValueT> {
 
   public abstract PredictorBuilder<ModelT, InputT, VectorT, ValueT> predictorBuilder();


### PR DESCRIPTION
This is to enable a user to compose their predictor with the pre-baked metrics as well as their own custom metrics.