### PR TITLE
Move metric type params to interface

### DIFF
--- a/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/PredictMetrics.java
+++ b/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/PredictMetrics.java
@@ -26,8 +26,8 @@ import java.util.List;
 /**
  * Defines an interface for how to collect prediction statistics.
  */
-public interface PredictMetrics {
+public interface PredictMetrics<InputT, ValueT> {
 
-  <InputT, ValueT> void prediction(List<Prediction<InputT, ValueT>> predictions);
+  void prediction(List<Prediction<InputT, ValueT>> predictions);
 
 }

--- a/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/VectorMetrics.java
+++ b/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/VectorMetrics.java
@@ -26,8 +26,8 @@ import java.util.List;
 /**
  * Defines an interface for how to collect vector statistics.
  */
-public interface VectorMetrics {
+public interface VectorMetrics<InputT, ValueT> {
 
-  <InputT, ValueT> void extraction(List<Vector<InputT, ValueT>> vectors);
+  void extraction(List<Vector<InputT, ValueT>> vectors);
 
 }

--- a/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/semantic/SemanticPredictMetrics.java
+++ b/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/semantic/SemanticPredictMetrics.java
@@ -31,7 +31,8 @@ import java.util.List;
  * Semantic metric implementation for the {@link PredictMetrics}.
  */
 @AutoValue
-public abstract class SemanticPredictMetrics implements PredictMetrics {
+public abstract class SemanticPredictMetrics<InputT, ValueT>
+    implements PredictMetrics<InputT, ValueT> {
 
   abstract Timer.Context predictDurationTimer();
 
@@ -43,7 +44,7 @@ public abstract class SemanticPredictMetrics implements PredictMetrics {
   }
 
   @Override
-  public <InputT, ValueT> void prediction(final List<Prediction<InputT, ValueT>> predictions) {
+  public void prediction(final List<Prediction<InputT, ValueT>> predictions) {
     predictDurationTimer().stop();
     predictRateCounter().mark(predictions.size());
   }

--- a/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/semantic/SemanticVectorMetrics.java
+++ b/zoltar-metrics/src/main/java/com/spotify/zoltar/metrics/semantic/SemanticVectorMetrics.java
@@ -31,7 +31,8 @@ import java.util.List;
  * Semantic metric implementation for the {@link VectorMetrics}.
  */
 @AutoValue
-public abstract class SemanticVectorMetrics implements VectorMetrics {
+public abstract class SemanticVectorMetrics<InputT, ValueT>
+    implements VectorMetrics<InputT, ValueT> {
 
   abstract Timer.Context extractDurationTimer();
 
@@ -43,7 +44,7 @@ public abstract class SemanticVectorMetrics implements VectorMetrics {
   }
 
   @Override
-  public <InputT, ValueT> void extraction(final List<Vector<InputT, ValueT>> vectors) {
+  public void extraction(final List<Vector<InputT, ValueT>> vectors) {
     extractDurationTimer().stop();
     extractRateCounter().mark(vectors.size());
   }


### PR DESCRIPTION
The type of predict and extract metric implementations should be bound to the types of of the predictFn and extractFns, respectively. This enables custom metrics to be computed based on the result types.