### PR TITLE
Rework extract fns

### DIFF
--- a/examples/batch-predictor/pom.xml
+++ b/examples/batch-predictor/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <artifactId>zoltar-parent</artifactId>
+    <groupId>com.spotify</groupId>
+    <version>0.4.1-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>batch-predictor</artifactId>
+
+  <properties>
+    <findbugs.excludeFilterFile>findbugsexclude.xml</findbugs.excludeFilterFile>
+    <maven.install.skip>true</maven.install.skip>
+    <checkstyle.violationSeverity>warning</checkstyle.violationSeverity>
+    <jacoco.skip>true</jacoco.skip>
+    <jackson.version>2.9.2</jackson.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.spotify</groupId>
+        <artifactId>zoltar-bom</artifactId>
+        <version>0.4.1-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>zoltar-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>zoltar-tests</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/batch-predictor/src/main/java/com/spotify/zoltar/examples/batch/BatchPredictorExample.java
+++ b/examples/batch-predictor/src/main/java/com/spotify/zoltar/examples/batch/BatchPredictorExample.java
@@ -1,0 +1,77 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.batch;
+
+import com.spotify.zoltar.FeatureExtractFns.BatchExtractFn;
+import com.spotify.zoltar.ModelLoader;
+import com.spotify.zoltar.PredictFns.PredictFn;
+import com.spotify.zoltar.Prediction;
+import com.spotify.zoltar.Predictor;
+import com.spotify.zoltar.PredictorBuilder;
+import com.spotify.zoltar.Predictors;
+import com.spotify.zoltar.loaders.Preloader;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Example showing a batch predictor.
+ */
+class BatchPredictorExample implements Predictor<List<Integer>, List<Float>> {
+
+  private PredictorBuilder<DummyModel, List<Integer>, List<Float>, List<Float>> predictorBuilder;
+
+  BatchPredictorExample() {
+    final ModelLoader<DummyModel> modelLoader = ModelLoader
+        .lift(DummyModel::new)
+        .with(Preloader.preload(Duration.ofMinutes(1)));
+
+    final BatchExtractFn<Integer, Float> batchExtractFn =
+        BatchExtractFn.lift((Function<Integer, Float>) input -> (float) input / 10);
+
+    final PredictFn<DummyModel, List<Integer>, List<Float>, List<Float>> predictFn =
+        (model, vectors) -> {
+          return vectors.stream()
+              .map(vector -> {
+                final List<Float> values = vector.value().stream().map(v -> v * 2)
+                    .collect(Collectors.toList());
+
+                return Prediction.create(vector.input(), values);
+              })
+              .collect(Collectors.toList());
+        };
+
+    // We build the PredictorBuilder as usual
+    predictorBuilder = Predictors.newBuilder(modelLoader, batchExtractFn, predictFn);
+  }
+
+  @Override
+  public CompletionStage<List<Prediction<List<Integer>, List<Float>>>> predict(
+      final ScheduledExecutorService scheduler,
+      final Duration timeout,
+      final List<Integer>... input) {
+    return predictorBuilder.predictor().predict(scheduler, timeout, input);
+  }
+
+}

--- a/examples/batch-predictor/src/main/java/com/spotify/zoltar/examples/batch/DummyModel.java
+++ b/examples/batch-predictor/src/main/java/com/spotify/zoltar/examples/batch/DummyModel.java
@@ -1,0 +1,38 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.batch;
+
+import com.spotify.zoltar.Model;
+
+class DummyModel implements Model<Object> {
+  @Override
+  public Id id() {
+    return Id.create("dummy");
+  }
+
+  @Override
+  public Object instance() {
+    return new Object();
+  }
+
+  @Override
+  public void close() throws Exception {}
+}

--- a/examples/batch-predictor/src/test/java/com/spotify/zoltar/examples/batch/BatchPredictorExampleTest.java
+++ b/examples/batch-predictor/src/test/java/com/spotify/zoltar/examples/batch/BatchPredictorExampleTest.java
@@ -1,0 +1,54 @@
+/*-
+ * -\-\-
+ * custom-metrics
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.examples.batch;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.zoltar.Prediction;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class BatchPredictorExampleTest {
+
+  @Test
+  public void testCustomMetrics() {
+    final BatchPredictorExample example = new BatchPredictorExample();
+
+    final List<Integer> batch = ImmutableList.of(3, 1, -4, -42, 42, -10);
+    final List<Float> predictions = example.predict(batch)
+        .toCompletableFuture()
+        .join()
+        .stream()
+        .map(Prediction::value)
+        .findFirst()
+        .orElse(Collections.emptyList());
+
+    final List<Float> expected = batch.stream()
+        .map(v -> (float) v / 10 * 2)
+        .collect(Collectors.toList());
+
+    assertThat(predictions, is(expected));
+  }
+}

--- a/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/CustomMetricsExample.java
+++ b/examples/custom-metrics/src/main/java/com/spotify/zoltar/examples/metrics/CustomMetricsExample.java
@@ -27,7 +27,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
-import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.FeatureExtractor;
 import com.spotify.zoltar.Model;
 import com.spotify.zoltar.ModelLoader;
@@ -168,7 +168,7 @@ class CustomMetricsExample implements Predictor<Integer, Float> {
     final ModelLoader<DummyModel> modelLoader = ModelLoader
         .lift(DummyModel::new)
         .with(Preloader.preload(Duration.ofMinutes(1)));
-    final SingleExtractFn<Integer, Float> extractFn = input -> (float) input / 10;
+    final ExtractFn<Integer, Float> extractFn = ExtractFn.lift(input -> (float) input / 10);
     final PredictFn<DummyModel, Integer, Float, Float> predictFn = (model, vectors) -> {
       return vectors.stream()
           .map(vector -> Prediction.create(vector.input(), vector.value() * 2))

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>examples/apollo-service-example</module>
     <module>examples/custom-metrics</module>
     <module>examples/mlengine-example</module>
+    <module>examples/batch-predictor</module>
   </modules>
 
   <properties>

--- a/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
@@ -81,5 +81,9 @@ public interface FeatureExtractFns {
         return output.build();
       };
     }
+
+    static <InputT, ValueT> BatchExtractFn<InputT, ValueT> lift(final Function<InputT, ValueT> fn) {
+      return lift(ExtractFn.lift(fn));
+    }
   }
 }

--- a/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
@@ -80,4 +80,31 @@ public interface FeatureExtractFns {
     }
   }
 
+  /**
+   * Generic feature extraction function, takes a batch of raw inputs and should return extracted
+   * features of user defined type for each input.
+   *
+   * @param <InputT> type of the input to feature extraction.
+   * @param <ValueT> type of feature extraction result.
+   */
+  @FunctionalInterface
+  interface BatchExtractFn<InputT, ValueT> extends ExtractFn<List<InputT>, List<ValueT>> {
+
+    /**
+     * Functional interface. Perform feature extraction.
+     */
+    ValueT apply(InputT input) throws Exception;
+
+    default List<List<ValueT>> apply(final List<InputT>... batches) throws Exception {
+      final ImmutableList.Builder<List<ValueT>> output = ImmutableList.builder();
+      for (final List<InputT> batch : batches) {
+        final ImmutableList.Builder<ValueT> outBatch = ImmutableList.builder();
+        for (final InputT input : batch) {
+          outBatch.add(apply(input));
+        }
+        output.add(outBatch.build());
+      }
+      return output.build();
+    }
+  }
 }

--- a/zoltar-featran/src/main/java/com/spotify/zoltar/featran/FeatranExtractFns.java
+++ b/zoltar-featran/src/main/java/com/spotify/zoltar/featran/FeatranExtractFns.java
@@ -25,8 +25,7 @@ import com.spotify.featran.java.DoubleSparseArray;
 import com.spotify.featran.java.FloatSparseArray;
 import com.spotify.featran.java.JFeatureSpec;
 import com.spotify.featran.xgboost.SparseLabeledPoint;
-import com.spotify.zoltar.FeatureExtractFns.BatchExtractFn;
-import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.FeatureExtractor;
 import ml.dmlc.xgboost4j.LabeledPoint;
 import org.tensorflow.example.Example;
@@ -46,11 +45,11 @@ public final class FeatranExtractFns {
    * Extract features as {@code double[]}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, double[]> doubles(
+  public static <InputT> ExtractFn<InputT, double[]> doubles(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return doubles(JFeatureSpec.wrap(featureSpec), settings);
@@ -60,25 +59,25 @@ public final class FeatranExtractFns {
    * Extract features as {@code double[]}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, double[]> doubles(
+  public static <InputT> ExtractFn<InputT, double[]> doubles(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsDouble(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsDouble(settings)::featureValue);
   }
 
   /**
    * Extract features as {@link Example}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, Example> example(
+  public static <InputT> ExtractFn<InputT, Example> example(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return example(JFeatureSpec.wrap(featureSpec), settings);
@@ -88,55 +87,25 @@ public final class FeatranExtractFns {
    * Extract features as {@link Example}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
-   * @return feature extraction result.
-   */
-  public static <InputT> SingleExtractFn<InputT, Example> example(
-      final JFeatureSpec<InputT> featureSpec,
-      final String settings) {
-    return featureSpec.extractWithSettingsExample(settings)::featureValue;
-  }
-
-  /**
-   * Extract features as a batch of {@link Example}.
-   *
-   * @param featureSpec Featran's {@link FeatureSpec}.
    * @param settings    JSON settings from a previous session.
    * @param <InputT>    type of the input to feature extraction.
-   *
    * @return feature extraction result.
    */
-  public static <InputT> BatchExtractFn<InputT, Example> exampleBatch(
-      final FeatureSpec<InputT> featureSpec,
-      final String settings) {
-    return exampleBatch(JFeatureSpec.wrap(featureSpec), settings);
-  }
-
-  /**
-   * Extract features as a batch of {@link Example}.
-   *
-   * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings    JSON settings from a previous session.
-   * @param <InputT>    type of the input to feature extraction.
-   *
-   * @return feature extraction result.
-   */
-  public static <InputT> BatchExtractFn<InputT, Example> exampleBatch(
+  public static <InputT> ExtractFn<InputT, Example> example(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsExample(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsExample(settings)::featureValue);
   }
 
   /**
    * Extract features as {@code float[]}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, float[]> floats(
+  public static <InputT> ExtractFn<InputT, float[]> floats(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return floats(JFeatureSpec.wrap(featureSpec), settings);
@@ -146,25 +115,25 @@ public final class FeatranExtractFns {
    * Extract features as {@code float[]}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, float[]> floats(
+  public static <InputT> ExtractFn<InputT, float[]> floats(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsFloat(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsFloat(settings)::featureValue);
   }
 
   /**
    * Extract features as {@link FloatSparseArray}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, FloatSparseArray> sparseFloats(
+  public static <InputT> ExtractFn<InputT, FloatSparseArray> sparseFloats(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return sparseFloats(JFeatureSpec.wrap(featureSpec), settings);
@@ -174,25 +143,25 @@ public final class FeatranExtractFns {
    * Extract features as {@link FloatSparseArray}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, FloatSparseArray> sparseFloats(
+  public static <InputT> ExtractFn<InputT, FloatSparseArray> sparseFloats(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsFloatSparseArray(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsFloatSparseArray(settings)::featureValue);
   }
 
   /**
    * Extract features as {@link DoubleSparseArray}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, DoubleSparseArray> sparseDoubles(
+  public static <InputT> ExtractFn<InputT, DoubleSparseArray> sparseDoubles(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return sparseDoubles(JFeatureSpec.wrap(featureSpec), settings);
@@ -202,25 +171,25 @@ public final class FeatranExtractFns {
    * Extract features as {@link DoubleSparseArray}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, DoubleSparseArray> sparseDoubles(
+  public static <InputT> ExtractFn<InputT, DoubleSparseArray> sparseDoubles(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsDoubleSparseArray(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsDoubleSparseArray(settings)::featureValue);
   }
 
   /**
    * Extract features as {@link LabeledPoint}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, LabeledPoint> labeledPoints(
+  public static <InputT> ExtractFn<InputT, LabeledPoint> labeledPoints(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return labeledPoints(JFeatureSpec.wrap(featureSpec), settings);
@@ -230,25 +199,25 @@ public final class FeatranExtractFns {
    * Extract features as {@link LabeledPoint}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, LabeledPoint> labeledPoints(
+  public static <InputT> ExtractFn<InputT, LabeledPoint> labeledPoints(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsLabeledPoint(settings)::featureValue;
+    return ExtractFn.lift(featureSpec.extractWithSettingsLabeledPoint(settings)::featureValue);
   }
 
   /**
    * Extract features as {@link SparseLabeledPoint}.
    *
    * @param featureSpec Featran's {@link FeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, SparseLabeledPoint> sparseLabeledPoints(
+  public static <InputT> ExtractFn<InputT, SparseLabeledPoint> sparseLabeledPoints(
       final FeatureSpec<InputT> featureSpec,
       final String settings) {
     return sparseLabeledPoints(JFeatureSpec.wrap(featureSpec), settings);
@@ -258,14 +227,15 @@ public final class FeatranExtractFns {
    * Extract features as {@link SparseLabeledPoint}.
    *
    * @param featureSpec Featran's {@link JFeatureSpec}.
-   * @param settings JSON settings from a previous session.
-   * @param <InputT> type of the input to feature extraction.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
    * @return feature extraction result.
    */
-  public static <InputT> SingleExtractFn<InputT, SparseLabeledPoint> sparseLabeledPoints(
+  public static <InputT> ExtractFn<InputT, SparseLabeledPoint> sparseLabeledPoints(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
-    return featureSpec.extractWithSettingsSparseLabeledPoint(settings)::featureValue;
+    return ExtractFn
+        .lift(featureSpec.extractWithSettingsSparseLabeledPoint(settings)::featureValue);
   }
 
 }

--- a/zoltar-featran/src/main/java/com/spotify/zoltar/featran/FeatranExtractFns.java
+++ b/zoltar-featran/src/main/java/com/spotify/zoltar/featran/FeatranExtractFns.java
@@ -25,6 +25,7 @@ import com.spotify.featran.java.DoubleSparseArray;
 import com.spotify.featran.java.FloatSparseArray;
 import com.spotify.featran.java.JFeatureSpec;
 import com.spotify.featran.xgboost.SparseLabeledPoint;
+import com.spotify.zoltar.FeatureExtractFns.BatchExtractFn;
 import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
 import com.spotify.zoltar.FeatureExtractor;
 import ml.dmlc.xgboost4j.LabeledPoint;
@@ -92,6 +93,36 @@ public final class FeatranExtractFns {
    * @return feature extraction result.
    */
   public static <InputT> SingleExtractFn<InputT, Example> example(
+      final JFeatureSpec<InputT> featureSpec,
+      final String settings) {
+    return featureSpec.extractWithSettingsExample(settings)::featureValue;
+  }
+
+  /**
+   * Extract features as a batch of {@link Example}.
+   *
+   * @param featureSpec Featran's {@link FeatureSpec}.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
+   *
+   * @return feature extraction result.
+   */
+  public static <InputT> BatchExtractFn<InputT, Example> exampleBatch(
+      final FeatureSpec<InputT> featureSpec,
+      final String settings) {
+    return exampleBatch(JFeatureSpec.wrap(featureSpec), settings);
+  }
+
+  /**
+   * Extract features as a batch of {@link Example}.
+   *
+   * @param featureSpec Featran's {@link JFeatureSpec}.
+   * @param settings    JSON settings from a previous session.
+   * @param <InputT>    type of the input to feature extraction.
+   *
+   * @return feature extraction result.
+   */
+  public static <InputT> BatchExtractFn<InputT, Example> exampleBatch(
       final JFeatureSpec<InputT> featureSpec,
       final String settings) {
     return featureSpec.extractWithSettingsExample(settings)::featureValue;

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/FeatureExtractFnsTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/FeatureExtractFnsTest.java
@@ -1,0 +1,47 @@
+/*-
+ * -\-\-
+ * zoltar-tests
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.zoltar.FeatureExtractFns.BatchExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
+import java.util.List;
+import org.junit.Test;
+
+public class FeatureExtractFnsTest {
+
+  @Test
+  public void batchExtractFn() throws Exception {
+    final ExtractFn<Integer, Double> fn = ExtractFn.lift(Integer::doubleValue);
+    final BatchExtractFn<Integer, Double> batchFn = BatchExtractFn.lift(fn);
+
+    final List<List<Double>> extracted =
+        batchFn.apply(ImmutableList.of(1), ImmutableList.of(2));
+    final List<List<Double>> expected =
+        ImmutableList.of(ImmutableList.of(1d), ImmutableList.of(2d));
+
+    assertThat(extracted, is(expected));
+  }
+
+}

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/FeatureExtractorTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/FeatureExtractorTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
-import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import java.util.Collections;
 import java.util.List;
 import org.hamcrest.core.Is;
@@ -42,7 +42,7 @@ public class FeatureExtractorTest {
 
   @Test
   public void nonEmptyExtract() throws Exception {
-    final SingleExtractFn<Integer, Float> fn = input -> (float) input / 10;
+    final ExtractFn<Integer, Float> fn = ExtractFn.lift(input -> (float) input / 10);
     final List<Vector<Integer, Float>> vectors = FeatureExtractor.create(fn).extract(null, 1);
 
     assertThat(vectors.size(), is(1));

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/PredictorBuilderTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/PredictorBuilderTest.java
@@ -24,7 +24,7 @@ package com.spotify.zoltar;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.PredictFns.AsyncPredictFn;
 import com.spotify.zoltar.PredictFns.PredictFn;
 import java.util.List;
@@ -101,7 +101,7 @@ public class PredictorBuilderTest {
   public void identityDecoration() throws ExecutionException, InterruptedException {
     final ModelLoader<DummyModel> loader =
         ModelLoader.lift(DummyModel::new);
-    final SingleExtractFn<Integer, Float> extractFn = input -> (float) input / 10;
+    final ExtractFn<Integer, Float> extractFn = ExtractFn.lift(input -> (float) input / 10);
     final PredictFn<DummyModel, Integer, Float, Float> predictFn = (model, vectors) -> {
       return vectors.stream()
           .map(vector -> Prediction.create(vector.input(), vector.value() * 2))

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/PredictorTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/PredictorTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
-import com.spotify.zoltar.FeatureExtractFns.SingleExtractFn;
+import com.spotify.zoltar.FeatureExtractFns.ExtractFn;
 import com.spotify.zoltar.PredictFns.AsyncPredictFn;
 import com.spotify.zoltar.PredictFns.PredictFn;
 import java.time.Duration;
@@ -104,7 +104,7 @@ public class PredictorTest {
   @Test
   public void nonEmpty() throws InterruptedException, ExecutionException, TimeoutException {
     final Duration wait = Duration.ofSeconds(1);
-    final SingleExtractFn<Integer, Float> extractFn = input -> (float) input / 10;
+    final ExtractFn<Integer, Float> extractFn = ExtractFn.lift(input -> (float) input / 10);
     final PredictFn<DummyModel, Integer, Float, Float> predictFn = (model, vectors) -> {
       return vectors.stream()
           .map(vector -> Prediction.create(vector.input(), vector.value() * 2))


### PR DESCRIPTION
this approach removes the need for the `SingleExtracFn`. Any function of `Function<InputT, ValueT>` can be lifted to an `ExtractFn`.

Also, when having batches of `List<InputT>` we can just lift any `ExtractFn` to a `BatchExtractFn`.

@ravwojdyla @yonromai PTAL

this will close #125