### PR TITLE
Revert TensorFlow to 1.8.0

### DIFF
--- a/zoltar-bom/pom.xml
+++ b/zoltar-bom/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <scala.version>2.11.12</scala.version>
-    <tensorFlow.version>1.9.0</tensorFlow.version>
+    <tensorFlow.version>1.8.0</tensorFlow.version>
     <scio.version>0.5.5</scio.version>
     <featran.version>0.1.27</featran.version>
     <proto.version>3.5.1</proto.version>


### PR DESCRIPTION
@ravwojdyla found a potential issue with the new version. Let's do this in the next release.