### PR TITLE
Support multi-dimensional string tensors

### DIFF
--- a/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/JTensor.java
+++ b/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/JTensor.java
@@ -20,9 +20,13 @@
 
 package com.spotify.zoltar.tf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
+import java.lang.reflect.Array;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -44,9 +48,20 @@ public abstract class JTensor implements Serializable {
 
     switch (tensor.dataType()) {
       case STRING:
-        final String value = new String(tensor.bytesValue());
-        jt = new AutoValue_JTensor(
+        if (tensor.numDimensions() == 0) {
+          final String value = new String(tensor.bytesValue(), UTF_8);
+          jt = new AutoValue_JTensor(
                 tensor.dataType(), tensor.numDimensions(), tensor.shape(), value);
+        } else {
+          final int[] dimensions = toIntExact(tensor.shape());
+          final Object byteArray =
+              tensor.copyTo(Array.newInstance(byte[].class, toIntExact(tensor.shape())));
+          jt = new AutoValue_JTensor(
+              tensor.dataType(),
+              tensor.numDimensions(),
+              tensor.shape(),
+              toStringArray(byteArray, tensor.numElements(), dimensions));
+        }
         break;
       case INT32:
         final IntBuffer intBuf = IntBuffer.allocate(tensor.numElements());
@@ -99,10 +114,20 @@ public abstract class JTensor implements Serializable {
   protected abstract Object data();
 
   /**
-   * String value of the underlying {@link Tensor}, if {@link DataType} is {@code STRING}.
+   * Value of the underlying {@link Tensor}, lets the caller take care of typing.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> T value() {
+    return (T) data();
+  }
+
+  /**
+   * String value of the underlying {@link Tensor}, if {@link DataType} is {@code STRING} and
+   * {@link #numDimensions()} is 0.
    */
   public String stringValue() {
     Preconditions.checkState(dataType() == DataType.STRING);
+    Preconditions.checkState(this.numDimensions() == 0);
     return (String) data();
   }
 
@@ -136,5 +161,53 @@ public abstract class JTensor implements Serializable {
   public double[] doubleValue() {
     Preconditions.checkState(dataType() == DataType.DOUBLE);
     return (double []) data();
+  }
+
+  private static int[] toIntExact(final long[] dimensions) {
+    // stream would look nice but this is probably faster
+    final int[] intDimensions = new int[dimensions.length];
+    for (int i = 0; i < dimensions.length; i++) {
+      intDimensions[i] = Math.toIntExact(dimensions[i]);
+    }
+    return intDimensions;
+  }
+
+  @VisibleForTesting
+  static Object toStringArray(
+      final Object byteArray,
+      final int numElements,
+      final int... dimensions)  {
+    final int numDimensions = dimensions.length;
+    final Object stringArray = Array.newInstance(String.class, dimensions);
+    final int[] currentIndexes = new int[numDimensions];
+
+    // iterate all elements
+    for (int n = 0; n < numElements; n++) {
+
+      // make currentIndexes point to the element we are populating in a multidimensional array
+      int quotient = n;
+      for (int d = numDimensions - 1; d >= 0; d--) {
+        currentIndexes[d] = quotient % dimensions[d];
+        quotient = quotient / dimensions[d];
+      }
+
+      // walk down the input array to select the corresponding byte[]
+      Object currentSubByteArray = byteArray;
+      for (int i = 0; i < numDimensions; i++) {
+        currentSubByteArray = Array.get(currentSubByteArray, currentIndexes[i]);
+      }
+
+      // walk down the output array to select parent array of current position so we can set
+      final String value = new String((byte[]) currentSubByteArray, UTF_8);
+      Object currentSubStringArray = stringArray;
+      for (int i = 0; i < numDimensions - 1; i++) {
+        currentSubStringArray = Array.get(currentSubStringArray, currentIndexes[i]);
+      }
+
+      // set the value
+      Array.set(currentSubStringArray, currentIndexes[numDimensions - 1], value);
+    }
+
+    return stringArray;
   }
 }

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/tf/JTensorTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/tf/JTensorTest.java
@@ -20,12 +20,14 @@
 
 package com.spotify.zoltar.tf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.Arrays;
 import java.util.function.Function;
 import org.junit.Test;
 import org.tensorflow.DataType;
@@ -33,6 +35,19 @@ import org.tensorflow.Tensor;
 import org.tensorflow.Tensors;
 
 public class JTensorTest {
+
+  private static final String[] STRING_ARRAY_1DIMENSION = {"0", "1", "2"};
+  private static final String[][][] STRING_ARRAY_3DIMENSIONS = {
+      {{"000", "001", "002"},{"010", "011", "012"}, {"020", "021", "022"}},
+      {{"100", "101", "102"},{"110", "111", "012"}, {"120", "121", "122"}},
+      {{"200", "201", "202"},{"210", "211", "212"}, {"220", "221", "222"}}
+  };
+  private static final String[][][] STRING_ARRAY_3DIMENSIONS_ASCENDING = {
+      {{"000", "001", "002"}, {"010", "011", "012"}}
+  };
+  private static final String[][][] STRING_ARRAY_3DIMENSIONS_DESCENDING = {
+      {{"000"}, {"010"}}, {{"100"}, {"110"}}, {{"200"}, {"210"}}
+  };
 
   private final long[] shape = {5L};
 
@@ -49,6 +64,38 @@ public class JTensorTest {
     testException(jt, JTensor::longValue);
     testException(jt, JTensor::floatValue);
     testException(jt, JTensor::doubleValue);
+  }
+
+  @Test
+  public void testStringTensor1Dimension() {
+    final byte[][] byteArray = toByteArray(STRING_ARRAY_1DIMENSION);
+    final Tensor<String> tensor = Tensors.create(byteArray);
+    final JTensor jt = JTensor.create(tensor);
+    testMultidimensionalStringTensor(jt, STRING_ARRAY_1DIMENSION, new long[]{3});
+  }
+
+  @Test
+  public void testStringTensor3Dimensions() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS);
+    final Tensor<String> tensor = Tensors.create(byteArray);
+    final JTensor jt = JTensor.create(tensor);
+    testMultidimensionalStringTensor(jt, STRING_ARRAY_3DIMENSIONS, new long[]{3, 3, 3});
+  }
+
+  @Test
+  public void testStringTensor3DimensionsAscending() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS_ASCENDING);
+    final Tensor<String> tensor = Tensors.create(byteArray);
+    final JTensor jt = JTensor.create(tensor);
+    testMultidimensionalStringTensor(jt, STRING_ARRAY_3DIMENSIONS_ASCENDING, new long[]{1, 2, 3});
+  }
+
+  @Test
+  public void testStringTensor3DimensionsDescending() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS_DESCENDING);
+    final Tensor<String> tensor = Tensors.create(byteArray);
+    final JTensor jt = JTensor.create(tensor);
+    testMultidimensionalStringTensor(jt, STRING_ARRAY_3DIMENSIONS_DESCENDING, new long[]{3, 2, 1});
   }
 
   @Test
@@ -121,6 +168,14 @@ public class JTensorTest {
   }
 
   @Test
+  public void multidimensionalStringTensorSerializable() throws IOException {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS);
+    final Tensor<String> tensor = Tensors.create(byteArray);
+    final JTensor jt = JTensor.create(tensor);
+    new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(jt);
+  }
+
+  @Test
   public void intTensorSerializable() throws IOException {
     final int[] intValue = {1, 2, 3, 4, 5};
     final Tensor<Integer> tensor = Tensors.create(intValue);
@@ -156,6 +211,42 @@ public class JTensorTest {
     new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(jt);
   }
 
+  @Test
+  public void testToStringArray1DimensionEmpty() {
+    final String[] stringArray = new String[]{};
+    final byte[][] byteArray = toByteArray(stringArray);
+    assertArrayEquals(stringArray,
+        (String[]) JTensor.toStringArray(byteArray, byteArray.length, new int[]{0}));
+  }
+
+  @Test
+  public void testToStringArray1Dimension() {
+    final byte[][] byteArray = toByteArray(STRING_ARRAY_1DIMENSION);
+    assertArrayEquals(STRING_ARRAY_1DIMENSION,
+        (String[]) JTensor.toStringArray(byteArray, 3, new int[]{3}));
+  }
+
+  @Test
+  public void testToStringArray3Dimensions() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS);
+    assertArrayEquals(STRING_ARRAY_3DIMENSIONS,
+        (String[][][]) JTensor.toStringArray(byteArray, 27, new int[]{3, 3, 3}));
+  }
+
+  @Test
+  public void testToStringArray3DimensionsAscending() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS_ASCENDING);
+    assertArrayEquals(STRING_ARRAY_3DIMENSIONS_ASCENDING,
+        (String[][][]) JTensor.toStringArray(byteArray, 6, new int[]{1, 2, 3}));
+  }
+
+  @Test
+  public void testToStringArray3DimensionsDescending() {
+    final byte[][][][] byteArray = toByteArray(STRING_ARRAY_3DIMENSIONS_DESCENDING);
+    assertArrayEquals(STRING_ARRAY_3DIMENSIONS_DESCENDING,
+        (String[][][]) JTensor.toStringArray(byteArray, 6, new int[]{3, 2, 1}));
+  }
+
   private <T> void testException(final JTensor jt, final Function<JTensor, T> fn) {
     try {
       fn.apply(jt);
@@ -163,5 +254,31 @@ public class JTensorTest {
     } catch (final IllegalStateException e) {
       // expected, do nothing
     }
+  }
+
+  private void testMultidimensionalStringTensor(final JTensor jt, Object[] expectedValue, final long[] expectedDimensions) {
+    assertEquals(DataType.STRING, jt.dataType());
+    assertEquals(expectedDimensions.length, jt.numDimensions());
+    assertArrayEquals(expectedDimensions, jt.shape());
+    assertArrayEquals(expectedValue, jt.value());
+    testException(jt, JTensor::stringValue);
+    testException(jt, JTensor::intValue);
+    testException(jt, JTensor::longValue);
+    testException(jt, JTensor::floatValue);
+    testException(jt, JTensor::doubleValue);
+  }
+
+  private byte[][] toByteArray(final String[] stringValue) {
+    return Arrays.stream(stringValue).map(item -> item.getBytes(UTF_8)).toArray(byte[][]::new);
+  }
+
+  private byte[][][][] toByteArray(final String[][][] stringValue) {
+    return Arrays.stream(stringValue)
+        .map(subArray1 -> Arrays.stream(subArray1)
+            .map(subArray2 -> Arrays.stream(subArray2)
+                .map(item -> item.getBytes(UTF_8))
+                .toArray(byte[][]::new))
+            .toArray(byte[][][]::new))
+        .toArray(byte[][][][]::new);
   }
 }


### PR DESCRIPTION
A quick and not super clean attempt at supporting multi-dimensional String tensors in `JTensor`. Comments are welcome.

This also makes sure that strings are always parsed using UTF-8 and not the machine's default encoding.