### PR TITLE
Fix wrong path

### DIFF
--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -7,7 +7,7 @@
 
 Common library for serving TensorFlow and XGBoost models in production.
 
-Zoltar is a library that helps load predictive machine learning models in a JVM. It provides several key abstractions which you can implement to help your service load a serialized model, featurize input data, submit feature vectors to the model, and serve the model's predictions. Below is a quick overview of these abstractions which can be found in @github[zoltar-core](../../zoltar-core/src/main/java/com/spotify/zoltar).
+Zoltar is a library that helps load predictive machine learning models in a JVM. It provides several key abstractions which you can implement to help your service load a serialized model, featurize input data, submit feature vectors to the model, and serve the model's predictions. Below is a quick overview of these abstractions which can be found in @github[zoltar-core](../../../zoltar-core/src/main/java/com/spotify/zoltar).
 
 ## Features
 


### PR DESCRIPTION
Hello
I fixed path for `zoltar-core` cause it seems wrong.
Also, link in `Abstractions` seems all broken. Where can I find it?

Thanks.