### PR TITLE
Use VectorT type param in extract APIs for consistency

### DIFF
--- a/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractFns.java
@@ -39,22 +39,22 @@ public interface FeatureExtractFns {
    * features of user defined type.
    *
    * @param <InputT> type of the input to feature extraction.
-   * @param <ValueT> type of feature extraction result.
+   * @param <VectorT> type of feature extraction result.
    */
   @FunctionalInterface
-  interface ExtractFn<InputT, ValueT> {
+  interface ExtractFn<InputT, VectorT> {
 
-    static <InputT, ValueT> ExtractFn<InputT, ValueT> lift(final Function<InputT, ValueT> fn) {
+    static <InputT, VectorT> ExtractFn<InputT, VectorT> lift(final Function<InputT, VectorT> fn) {
       return inputs -> Arrays.stream(inputs).map(fn).collect(Collectors.toList());
     }
 
     /**
      * Functional interface. Perform feature extraction.
      */
-    List<ValueT> apply(InputT... inputs) throws Exception;
+    List<VectorT> apply(InputT... inputs) throws Exception;
 
-    default <C extends ExtractFn<InputT, ValueT>> C with(
-        final Function<ExtractFn<InputT, ValueT>, C> fn) {
+    default <C extends ExtractFn<InputT, VectorT>> C with(
+        final Function<ExtractFn<InputT, VectorT>, C> fn) {
       return fn.apply(this);
     }
   }
@@ -64,15 +64,15 @@ public interface FeatureExtractFns {
    * features of user defined type for each input.
    *
    * @param <InputT> type of the input to feature extraction.
-   * @param <ValueT> type of feature extraction result.
+   * @param <VectorT> type of feature extraction result.
    */
   @FunctionalInterface
-  interface BatchExtractFn<InputT, ValueT> extends ExtractFn<List<InputT>, List<ValueT>> {
+  interface BatchExtractFn<InputT, VectorT> extends ExtractFn<List<InputT>, List<VectorT>> {
 
-    static <InputT, ValueT> BatchExtractFn<InputT, ValueT> lift(
-        final ExtractFn<InputT, ValueT> fn) {
+    static <InputT, VectorT> BatchExtractFn<InputT, VectorT> lift(
+        final ExtractFn<InputT, VectorT> fn) {
       return inputs -> {
-        final ImmutableList.Builder<List<ValueT>> output = ImmutableList.builder();
+        final ImmutableList.Builder<List<VectorT>> output = ImmutableList.builder();
         for (final List<InputT> batch: inputs) {
           final InputT[] objects = (InputT[]) batch.toArray(new Object[batch.size()]);
           output.add(fn.apply(objects));
@@ -82,7 +82,8 @@ public interface FeatureExtractFns {
       };
     }
 
-    static <InputT, ValueT> BatchExtractFn<InputT, ValueT> lift(final Function<InputT, ValueT> fn) {
+    static <InputT, VectorT> BatchExtractFn<InputT, VectorT> lift(
+        final Function<InputT, VectorT> fn) {
       return lift(ExtractFn.lift(fn));
     }
   }

--- a/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractor.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/FeatureExtractor.java
@@ -33,10 +33,10 @@ import java.util.function.Function;
  *
  * @param <ModelT>  underlying type of the {@link Model}.
  * @param <InputT> type of the input to feature extraction.
- * @param <ValueT> type of feature extraction result.
+ * @param <VectorT> type of feature extraction result.
  */
 @FunctionalInterface
-public interface FeatureExtractor<ModelT extends Model<?>, InputT, ValueT> {
+public interface FeatureExtractor<ModelT extends Model<?>, InputT, VectorT> {
 
   /**
    * Creates an extractor given a generic {@link ExtractFn}, consider using <a
@@ -45,14 +45,15 @@ public interface FeatureExtractor<ModelT extends Model<?>, InputT, ValueT> {
    *
    * @param fn {@link ExtractFn} extraction function
    * @param <InputT> type of the input to feature extraction.
-   * @param <ValueT> type of feature extraction result.
+   * @param <VectorT> type of feature extraction result.
    */
-  static <ModelT extends Model<?>, InputT, ValueT> FeatureExtractor<ModelT, InputT, ValueT> create(
-      final ExtractFn<InputT, ValueT> fn) {
+  @SuppressWarnings("checkstyle:LineLength")
+  static <ModelT extends Model<?>, InputT, VectorT> FeatureExtractor<ModelT, InputT, VectorT> create(
+      final ExtractFn<InputT, VectorT> fn) {
     return (model, inputs) -> {
-      final List<Vector<InputT, ValueT>> result = Lists.newArrayList();
+      final List<Vector<InputT, VectorT>> result = Lists.newArrayList();
       final Iterator<InputT> i1 = Arrays.asList(inputs).iterator();
-      final Iterator<ValueT> i2 = fn.apply(inputs).iterator();
+      final Iterator<VectorT> i2 = fn.apply(inputs).iterator();
       while (i1.hasNext() && i2.hasNext()) {
         result.add(Vector.create(i1.next(), i2.next()));
       }
@@ -61,10 +62,10 @@ public interface FeatureExtractor<ModelT extends Model<?>, InputT, ValueT> {
   }
 
   /** Functional interface. Perform the feature extraction given the input. */
-  List<Vector<InputT, ValueT>> extract(ModelT model, InputT... input) throws Exception;
+  List<Vector<InputT, VectorT>> extract(ModelT model, InputT... input) throws Exception;
 
-  default <C extends FeatureExtractor<ModelT, InputT, ValueT>> C with(
-      final Function<FeatureExtractor<ModelT, InputT, ValueT>, C> fn) {
+  default <C extends FeatureExtractor<ModelT, InputT, VectorT>> C with(
+      final Function<FeatureExtractor<ModelT, InputT, VectorT>, C> fn) {
     return fn.apply(this);
   }
 }


### PR DESCRIPTION
I found it a bit confusing that `ValueT` refers to the feature type here, where elsewhere `VectorT` is used for that purpose and `ValueT` refers to the prediction type. Renaming for consistency across the project.