### PR TITLE
Fix gcs path download

### DIFF
--- a/zoltar-core/src/main/java/com/spotify/zoltar/fs/FileSystemExtras.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/fs/FileSystemExtras.java
@@ -112,7 +112,7 @@ public final class FileSystemExtras {
         Files.walk(src).filter(path -> !path.equals(src)).collect(Collectors.toList());
 
     for (final Path path : paths) {
-      final Path relative = src.relativize(path);
+      final Path relative = src.relativize(path(path.toUri()));
       // The 'resolve' method can be passed a String or a Path - we must pass String. If copying
       // from a jar file, the relative path will be ZipPath, while our destination directory will
       // be UnixPath. This difference will cause resolve to throw ProviderMismatchException, so

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTest.java
@@ -20,13 +20,13 @@
 
 package com.spotify.zoltar.fs;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static com.spotify.zoltar.fs.FileSystemExtrasTestUtils.checkCopiedDirectory;
+import static com.spotify.zoltar.fs.FileSystemExtrasTestUtils.pathForJar;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -35,9 +35,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class FileSystemExtrasTest {
@@ -100,7 +97,7 @@ public class FileSystemExtrasTest {
     final Path dest = Files.createTempDirectory("zoltar-");
     final File file = FileSystemExtras.copyDir(src, dest, true).toFile();
     file.deleteOnExit();
-    checkCopiedDirectory(file);
+    checkCopiedDirectory(file, "variables", "saved_model.pb", "trained_model.txt");
   }
 
   @Test
@@ -110,22 +107,7 @@ public class FileSystemExtrasTest {
     final Path dest = Files.createTempDirectory("zoltar-");
     final File file = FileSystemExtras.copyDir(src, dest, true).toFile();
     file.deleteOnExit();
-    checkCopiedDirectory(file);
+    checkCopiedDirectory(file, "variables", "saved_model.pb", "trained_model.txt");
   }
 
-  private void checkCopiedDirectory(final File file) {
-    assertTrue(file.exists());
-    assertTrue(file.isDirectory());
-
-    final List<String> dirContents =
-        Arrays.stream(file.listFiles()).map(File::getName).collect(Collectors.toList());
-
-    assertThat(dirContents, containsInAnyOrder("variables", "saved_model.pb", "trained_model.txt"));
-  }
-
-  private Path pathForJar() throws IOException {
-    final String file = getClass().getResource("/trained_model.jar").getFile();
-    final URI uri = URI.create(String.format("jar:file:%s!/", file));
-    return FileSystemExtras.path(uri);
-  }
 }

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestIT.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestIT.java
@@ -1,0 +1,42 @@
+/*-
+ * -\-\-
+ * zoltar-core
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.fs;
+
+import static com.spotify.zoltar.fs.FileSystemExtrasTestUtils.checkCopiedDirectory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Test;
+
+public class FileSystemExtrasTestIT {
+
+  @Test
+  public void downloadGcsBucket() throws IOException {
+    final URI gcsUri = URI.create(
+        "gs://data-integration-test-us/zoltar/iris/trained/regadas/2018-04-16--14-47-55/export/1523904529");
+    final File local = new File(FileSystemExtras.downloadIfNonLocal(gcsUri));
+    local.deleteOnExit();
+
+    checkCopiedDirectory(local, "variables", "saved_model.pb");
+  }
+
+}

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestUtils.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestUtils.java
@@ -1,0 +1,53 @@
+/*-
+ * -\-\-
+ * zoltar-tests
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.fs;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class FileSystemExtrasTestUtils {
+
+  public static void checkCopiedDirectory(final File file, String... items) {
+    assertTrue(file.exists());
+    assertTrue(file.isDirectory());
+
+    final List<String> dirContents =
+        Arrays.stream(file.listFiles()).map(File::getName).collect(Collectors.toList());
+
+    assertThat(dirContents, containsInAnyOrder(items));
+  }
+
+  public static Path pathForJar() throws IOException {
+    final String file = FileSystemExtrasTestUtils.class.getResource("/trained_model.jar").getFile();
+    final URI uri = URI.create(String.format("jar:file:%s!/", file));
+    return FileSystemExtras.path(uri);
+  }
+
+}


### PR DESCRIPTION
Fixes `java.lang.IllegalArgumentException: 'other' is different type of Path` when downloading from a gcs path.