### PR TITLE
Fix for TensorFlowGraphLoader failure when loading model from GCS

### DIFF
--- a/zoltar-core/src/main/java/com/spotify/zoltar/fs/FileSystemExtras.java
+++ b/zoltar-core/src/main/java/com/spotify/zoltar/fs/FileSystemExtras.java
@@ -69,22 +69,6 @@ public final class FileSystemExtras {
       return Paths.get(uri.toString());
     }
 
-    // uri starts with 'gs'
-    if (scheme.equalsIgnoreCase(CloudStorageFileSystem.URI_SCHEME)) {
-      // GCS requires that the path has a trailing slash.
-      final URI trailingSlashUri = uri.toString().endsWith("/")
-                                   ? uri : URI.create(uri.toString() + "/");
-      try {
-        return Paths.get(trailingSlashUri);
-      } catch (IllegalArgumentException e) {
-        if (uri.getHost() == null && scheme.equalsIgnoreCase(CloudStorageFileSystem.URI_SCHEME)) {
-          // https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames
-          throw new IllegalArgumentException("gcs bucket is not rfc 2396 compliant");
-        }
-        throw e;
-      }
-    }
-
     try {
       return Paths.get(uri);
     } catch (FileSystemNotFoundException e) {
@@ -93,6 +77,12 @@ public final class FileSystemExtras {
       // https://docs.oracle.com/javase/7/docs/technotes/guides/io/fsp/zipfilesystemprovider.html
       FileSystems.newFileSystem(uri, Collections.emptyMap());
       return Paths.get(uri);
+    } catch (IllegalArgumentException e) {
+      if (uri.getHost() == null && scheme.equalsIgnoreCase(CloudStorageFileSystem.URI_SCHEME)) {
+        // https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames
+        throw new IllegalArgumentException("gcs bucket is not rfc 2396 compliant");
+      }
+      throw e;
     }
   }
 

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTest.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTest.java
@@ -58,7 +58,7 @@ public class FileSystemExtrasTest {
   @Test
   public void gcsPath() throws IOException {
     final Path gcsPath = FileSystemExtras.path(URI.create("gs://bucket/name"));
-    assertThat(gcsPath.toString(), equalTo("/name/"));
+    assertThat(gcsPath.toString(), equalTo("/name"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestIT.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/fs/FileSystemExtrasTestIT.java
@@ -32,7 +32,7 @@ public class FileSystemExtrasTestIT {
   @Test
   public void downloadGcsBucket() throws IOException {
     final URI gcsUri = URI.create(
-        "gs://data-integration-test-us/zoltar/iris/trained/regadas/2018-04-16--14-47-55/export/1523904529");
+        "gs://data-integration-test-us/zoltar/iris/trained/regadas/2018-04-16--14-47-55/export/1523904529/");
     final File local = new File(FileSystemExtras.downloadIfNonLocal(gcsUri));
     local.deleteOnExit();
 

--- a/zoltar-tests/src/test/java/com/spotify/zoltar/loaders/LoaderIT.java
+++ b/zoltar-tests/src/test/java/com/spotify/zoltar/loaders/LoaderIT.java
@@ -1,0 +1,109 @@
+/*-
+ * -\-\-
+ * zoltar-tests
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.zoltar.loaders;
+
+import static com.spotify.zoltar.fs.FileSystemExtrasTestUtils.jarUri;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.zoltar.tf.TensorFlowGraphLoader;
+import com.spotify.zoltar.tf.TensorFlowGraphModel;
+import com.spotify.zoltar.tf.TensorFlowLoader;
+import com.spotify.zoltar.tf.TensorFlowModel;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+public class LoaderIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  @Test
+  public void tfLoaderGcs() throws Exception {
+    // Load directory from GCS without trailing slash. GCS requires trailing slash for
+    // directories, so Zoltar should append it for us.
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/tensorflow/export";
+    final TensorFlowModel model = TensorFlowLoader.create(uri).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test
+  public void tfLoaderGcsTrailingSlash() throws Exception {
+    // Load directory from GCS with trailing slash, which GCS requires for directories.
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/tensorflow/export/";
+    final TensorFlowModel model = TensorFlowLoader.create(uri).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test
+  public void tfLoaderJar() throws Exception {
+    // Load directory from jar file without trailing slash.
+    final URI uri = jarUri();
+    final TensorFlowModel model = TensorFlowLoader.create(uri.toString()).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void tfLoaderJarTrailingSlash() throws Exception {
+    // Load directory from jar file with trailing slash. On Java 1.8 this will throw an exception
+    // because of ZipPath.relativize. See https://github.com/spotify/zoltar/pull/176 for more info.
+    // It will not throw an exception on Java 11.
+    final URI uri = jarUri();
+    final TensorFlowModel model = TensorFlowLoader.create(uri.toString() + "/").get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test
+  public void tfGraphLoader() throws Exception {
+    // Load a file from GCS without trailing slash
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/tensorflowGraph/tfgraph.bin";
+    final TensorFlowGraphModel model = TensorFlowGraphLoader.create(uri, null, null).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void tfGraphLoaderTrailingSlash() throws Exception {
+    // Load a file from GCS with trailing slash. This should throw an exception because GCS does
+    // not allow a trailing slash on files.
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/tensorflowGraph/tfgraph.bin/";
+    final TensorFlowGraphModel model = TensorFlowGraphLoader.create(uri, null, null).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test
+  public void xgBoostLoader() throws Exception {
+    // Load a file from GCS without trailing slash
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/xgBoost/model.xgb";
+    final TensorFlowGraphModel model = TensorFlowGraphLoader.create(uri, null, null).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void xgBoostLoaderTrailingSlash() throws Exception {
+    // Load a file from GCS with trailing slash. This should throw an exception because GCS does
+    // not allow a trailing slash on files.
+    final String uri = "gs://data-integration-test-us/zoltar/LoaderIT/xgBoost/model.xgb/";
+    final TensorFlowGraphModel model = TensorFlowGraphLoader.create(uri, null, null).get(TIMEOUT);
+    assertThat(model, notNullValue());
+  }
+
+}


### PR DESCRIPTION
PR #176 made it so that a trailing slash was appended to GCS URIs. This was
to fix downloading tensorflow directories, which requires the trailing slash.
This broke TensorFlowGraphLoader, because that downloads a single file, and
the GCS client throws an exception if a trailing slash is used with a file.

This PR makes it so that the trailing slash is appended by the TensorFlowLoader
class, not FileSystemExtras. The loader classes know if they are downloading
a file or a directory (FileSystemExtras does not), so they need to be responsible
for handling the slash.

Also added LoaderIT to test TensorFlowGraphLoader and TensorFlowLoader under
various conditions.