### PR TITLE
Loading metadata with tensorflow model

### DIFF
--- a/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/TensorFlowLoader.java
+++ b/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/TensorFlowLoader.java
@@ -87,6 +87,23 @@ public interface TensorFlowLoader extends ModelLoader<TensorFlowModel> {
   /**
    * Returns a TensorFlow model loader based on a saved model.
    *
+   * @param id       model id @{link Model.Id}.
+   * @param modelUri should point to a directory of the saved TensorFlow {@link
+   *                 org.tensorflow.SavedModelBundle}, can be a URI to a local filesystem, resource,
+   *                 GCS etc.
+   * @param options  TensorFlow options, see {@link TensorFlowModel.Options}.
+   * @param signatureDef name of the signature definition to load from the exported model
+   */
+  static TensorFlowLoader create(final Model.Id id,
+                                 final String modelUri,
+                                 final TensorFlowModel.Options options,
+                                 final String signatureDef) {
+    return create(() -> TensorFlowModel.create(id, URI.create(modelUri), options, signatureDef));
+  }
+
+  /**
+   * Returns a TensorFlow model loader based on a saved model.
+   *
    * @param supplier {@link TensorFlowModel} supplier.
    */
   static TensorFlowLoader create(final ThrowableSupplier<TensorFlowModel> supplier) {


### PR DESCRIPTION
This loads metadata with the tensorflow model

When a graph is exported, the person exporting defines the signature of the input/output mapping
This mapping is essentially an API for consumers of the model; so rather then specifying as input 
things like `placeholder:12` can you feed a map with "age" and that gets translated into the right node name. Loading this metadata will help with that
