### PR TITLE
tf: Ensure result tensors are closed

### DIFF
--- a/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/TensorFlowExtras.java
+++ b/zoltar-tensorflow/src/main/java/com/spotify/zoltar/tf/TensorFlowExtras.java
@@ -48,12 +48,15 @@ public class TensorFlowExtras {
     for (final String op : fetchOps) {
       runner.fetch(op);
     }
-    final List<Tensor<?>> tensors = runner.run();
     final Map<String, JTensor> result = Maps.newLinkedHashMapWithExpectedSize(fetchOps.length);
-    for (int i = 0; i < fetchOps.length; i++) {
-      final Tensor<?> tensor = tensors.get(i);
-      result.put(fetchOps[i], JTensor.create(tensor));
-      tensor.close();
+    final List<Tensor<?>> tensors = runner.run();
+    try {
+      for (int i = 0; i < fetchOps.length; i++) {
+        final Tensor<?> tensor = tensors.get(i);
+        result.put(fetchOps[i], JTensor.create(tensor));
+      }
+    } finally {
+      tensors.forEach(Tensor::close);
     }
     return result;
   }


### PR DESCRIPTION
We have some suspicion this may be responsible for a memory leak in one
of our services. But regardless, it's good practice.

Note: `runner.run` closes all the output tensors before throwing, so no concern there.

